### PR TITLE
Correct the container names + provide the managed identity

### DIFF
--- a/sources/azure.resources.definition.json
+++ b/sources/azure.resources.definition.json
@@ -260,7 +260,7 @@
       },
       "regex": "^(?=.{1,63}$)(?!.*--)[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]$",
       "scope": "resourceGroup",
-      "prefix": "cg",
+      "prefix": "ci",
       "dashes": true
     },
     {
@@ -271,7 +271,7 @@
       },
       "regex": "^(?=.{1,63}$)[a-zA-Z0-9]+$",
       "scope": "resourceGroup",
-      "prefix": "acr",
+      "prefix": "cr",
       "dashes": false
     },
     {
@@ -1031,6 +1031,17 @@
       "regex": "^(?=.{1,80}$)[a-zA-Z0-9_]+$",
       "scope": "resourceGroup",
       "prefix": "dsk",
+      "dashes": true
+    },
+    {
+      "name": "managed_identity",
+      "length": {
+        "min": 3,
+        "max": 128
+      },
+      "regex": "^(?=.{3,128}$)[a-zA-Z0-9][a-zA-Z0-9-_]+$",
+      "scope": "resourceGroup",
+      "prefix": "id",
       "dashes": true
     },
     {

--- a/starter-pack/modules/aznames.module.bicep
+++ b/starter-pack/modules/aznames.module.bicep
@@ -225,17 +225,17 @@ output names object = {
     dashes: true
   }
   containerGroup: {
-    refName: substring(replace(resourceNameTemplate, azureDummyResource, 'cg'), 0, min(length(replace(resourceNameTemplate, azureDummyResource, 'cg')), 63))
-    uniName: substring(replace(uniqueResourceNameTemplate, azureDummyResource, 'cg'), 0, min(length(replace(uniqueResourceNameTemplate, azureDummyResource, 'cg')), 63))
-    prefix: 'cg'
+    refName: substring(replace(resourceNameTemplate, azureDummyResource, 'ci'), 0, min(length(replace(resourceNameTemplate, azureDummyResource, 'ci')), 63))
+    uniName: substring(replace(uniqueResourceNameTemplate, azureDummyResource, 'ci'), 0, min(length(replace(uniqueResourceNameTemplate, azureDummyResource, 'ci')), 63))
+    prefix: 'ci'
     maxLength: 63
     scope: 'resourceGroup'
     dashes: true
   }
   containerRegistry: {
-    refName: substring(replace(resourceNameTemplateNoDashes, azureDummyResource, 'acr'), 0, min(length(replace(resourceNameTemplateNoDashes, azureDummyResource, 'acr')), 63))
-    uniName: substring(replace(uniqueResourceNameTemplateNoDashes, azureDummyResource, 'acr'), 0, min(length(replace(uniqueResourceNameTemplateNoDashes, azureDummyResource, 'acr')), 63))
-    prefix: 'acr'
+    refName: substring(replace(resourceNameTemplateNoDashes, azureDummyResource, 'cr'), 0, min(length(replace(resourceNameTemplateNoDashes, azureDummyResource, 'cr')), 63))
+    uniName: substring(replace(uniqueResourceNameTemplateNoDashes, azureDummyResource, 'cr'), 0, min(length(replace(uniqueResourceNameTemplateNoDashes, azureDummyResource, 'cr')), 63))
+    prefix: 'cr'
     maxLength: 63
     scope: 'resourceGroup'
     dashes: false
@@ -789,6 +789,14 @@ output names object = {
     uniName: substring(replace(uniqueResourceNameTemplate, azureDummyResource, 'dsk'), 0, min(length(replace(uniqueResourceNameTemplate, azureDummyResource, 'dsk')), 80))
     prefix: 'dsk'
     maxLength: 80
+    scope: 'resourceGroup'
+    dashes: true
+  }
+  managedIdentity: {
+    refName: substring(replace(resourceNameTemplate, azureDummyResource, 'id'), 0, min(length(replace(resourceNameTemplate, azureDummyResource, 'id')), 128))
+    uniName: substring(replace(uniqueResourceNameTemplate, azureDummyResource, 'id'), 0, min(length(replace(uniqueResourceNameTemplate, azureDummyResource, 'id')), 128))
+    prefix: 'id'
+    maxLength: 128
     scope: 'resourceGroup'
     dashes: true
   }


### PR DESCRIPTION
Introducing two changes:
1. According to the [resource abbreviation](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations), the container group and container registry and container groups should have `cr` and `ci` respectfully.
2. Introducing the managed identity naming rules [link to bicep](https://learn.microsoft.com/en-us/azure/templates/microsoft.managedidentity/userassignedidentities?pivots=deployment-language-bicep). According to the documentation: Character limit: 3-128 Valid characters: Alphanumerics, hyphens, and underscores. Start with a letter or number.